### PR TITLE
Add public methods for JSON serde

### DIFF
--- a/datafusion/proto/Cargo.toml
+++ b/datafusion/proto/Cargo.toml
@@ -34,7 +34,7 @@ path = "src/lib.rs"
 
 [features]
 default = []
-serde = ["pbjson", "pbjson-build", "dep:serde"]
+json = ["pbjson", "pbjson-build", "dep:serde"]
 
 [dependencies]
 arrow = { version = "18.0.0" }

--- a/datafusion/proto/Cargo.toml
+++ b/datafusion/proto/Cargo.toml
@@ -34,7 +34,7 @@ path = "src/lib.rs"
 
 [features]
 default = []
-json = ["pbjson", "pbjson-build", "dep:serde"]
+json = ["pbjson", "pbjson-build", "serde"]
 
 [dependencies]
 arrow = { version = "18.0.0" }

--- a/datafusion/proto/build.rs
+++ b/datafusion/proto/build.rs
@@ -28,7 +28,7 @@ fn main() -> Result<(), String> {
     Ok(())
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "json")]
 fn build() -> Result<(), String> {
     let descriptor_path = std::path::PathBuf::from(std::env::var("OUT_DIR").unwrap())
         .join("proto_descriptor.bin");
@@ -50,7 +50,7 @@ fn build() -> Result<(), String> {
     Ok(())
 }
 
-#[cfg(not(feature = "serde"))]
+#[cfg(not(feature = "json"))]
 fn build() -> Result<(), String> {
     tonic_build::configure()
         .compile(&["proto/datafusion.proto"], &["proto"])

--- a/datafusion/proto/src/lib.rs
+++ b/datafusion/proto/src/lib.rs
@@ -24,7 +24,7 @@ use datafusion_common::DataFusionError;
 pub mod protobuf {
     include!(concat!(env!("OUT_DIR"), "/datafusion.rs"));
 
-    #[cfg(feature = "serde")]
+    #[cfg(feature = "json")]
     include!(concat!(env!("OUT_DIR"), "/datafusion.serde.rs"));
 }
 
@@ -78,15 +78,15 @@ mod roundtrip_tests {
     use std::fmt::Formatter;
     use std::sync::Arc;
 
-    #[cfg(feature = "serde")]
-    fn roundtrip_serde_test(proto: &protobuf::LogicalExprNode) {
+    #[cfg(feature = "json")]
+    fn roundtrip_json_test(proto: &protobuf::LogicalExprNode) {
         let string = serde_json::to_string(proto).unwrap();
         let back: protobuf::LogicalExprNode = serde_json::from_str(&string).unwrap();
         assert_eq!(proto, &back);
     }
 
-    #[cfg(not(feature = "serde"))]
-    fn roundtrip_serde_test(_proto: &protobuf::LogicalExprNode) {}
+    #[cfg(not(feature = "json"))]
+    fn roundtrip_json_test(_proto: &protobuf::LogicalExprNode) {}
 
     // Given a DataFusion logical Expr, convert it to protobuf and back, using debug formatting to test
     // equality.
@@ -103,7 +103,7 @@ mod roundtrip_tests {
             format!("{:?}", round_trip)
         );
 
-        roundtrip_serde_test(&proto);
+        roundtrip_json_test(&proto);
     }
 
     fn new_box_field(name: &str, dt: DataType, nullable: bool) -> Box<Field> {


### PR DESCRIPTION
1. Add public methods for `to_json` and `from_json`
2. change the `serde` feature name to `json` (which seems more accurate/intuitive)